### PR TITLE
fix: allow existing namespaces to be used

### DIFF
--- a/internal/clients/kube/apply_client.go
+++ b/internal/clients/kube/apply_client.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
+
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
 	"k8s.io/apimachinery/pkg/types"
-	"strings"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"

--- a/internal/clients/kube/apply_client.go
+++ b/internal/clients/kube/apply_client.go
@@ -2,7 +2,10 @@ package kube
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"github.com/crossplane/crossplane-runtime/pkg/logging"
+	"k8s.io/apimachinery/pkg/types"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -21,6 +24,7 @@ type ApplyClient struct {
 	dynamicClient       dynamic.Interface
 	clientset           kubernetes.Interface
 	discoveryRestMapper meta.RESTMapper
+	logger              logging.Logger
 }
 
 type applyObject struct {
@@ -29,7 +33,7 @@ type applyObject struct {
 	unstructuredObj map[string]interface{}
 }
 
-func NewApplyClient(dynamicClient dynamic.Interface, clientset kubernetes.Interface) (*ApplyClient, error) {
+func NewApplyClient(dynamicClient dynamic.Interface, clientset kubernetes.Interface, logger logging.Logger) (*ApplyClient, error) {
 	groupResources, err := restmapper.GetAPIGroupResources(clientset.Discovery())
 	if err != nil {
 		return &ApplyClient{}, fmt.Errorf("error setting up API discovery for dynamic client: %w", err)
@@ -38,6 +42,7 @@ func NewApplyClient(dynamicClient dynamic.Interface, clientset kubernetes.Interf
 	return &ApplyClient{
 		dynamicClient:       dynamicClient,
 		clientset:           clientset,
+		logger:              logger,
 		discoveryRestMapper: restmapper.NewDiscoveryRESTMapper(groupResources),
 	}, nil
 }
@@ -61,6 +66,8 @@ func (a ApplyClient) ApplyManifests(ctx context.Context, manifests string, delet
 		if err != nil {
 			return err
 		}
+
+		a.logger.Debug("Applying k8s object", "name", applyObject.name, "gvk", gvk)
 
 		if delete {
 			err = a.deleteObject(ctx, mapping, applyObject)
@@ -132,19 +139,37 @@ func (a ApplyClient) deleteObject(ctx context.Context, mapping *meta.RESTMapping
 
 func (a ApplyClient) applyObject(ctx context.Context, mapping *meta.RESTMapping, applyObject applyObject) error {
 	if isClusterScopedResource(mapping.Resource.Resource) {
+		// Don't risk overwriting a namespace if it already exists
+		if mapping.Resource.Resource == "namespaces" {
+			_, err := a.dynamicClient.Resource(mapping.Resource).Get(ctx, applyObject.name, v1.GetOptions{})
+			if err != nil {
+				if errors.IsNotFound(err) {
+					_, err = a.dynamicClient.Resource(mapping.Resource).Apply(ctx, applyObject.name, &unstructured.Unstructured{Object: applyObject.unstructuredObj}, v1.ApplyOptions{FieldManager: "application/apply-patch"})
+					return err
+				}
+
+				return err
+			}
+
+			// Object already exists, just patch the namespace metadata.
+			metadata := applyObject.unstructuredObj["metadata"]
+			patchBytes, err := json.Marshal(metadata)
+			if err != nil {
+				return err
+			}
+
+			_, err = a.dynamicClient.Resource(mapping.Resource).Patch(ctx, applyObject.name, types.StrategicMergePatchType, patchBytes, v1.PatchOptions{FieldManager: "application/apply-patch"})
+			return err
+		}
+
 		_, err := a.dynamicClient.Resource(mapping.Resource).Apply(ctx, applyObject.name, &unstructured.Unstructured{Object: applyObject.unstructuredObj}, v1.ApplyOptions{FieldManager: "application/apply-patch"})
 		return err
 	}
 
 	_, err := a.dynamicClient.Resource(mapping.Resource).Namespace(applyObject.namespace).Apply(ctx, applyObject.name, &unstructured.Unstructured{Object: applyObject.unstructuredObj}, v1.ApplyOptions{FieldManager: "application/apply-patch"})
-
 	return err
 }
 
 func isClusterScopedResource(resource string) bool {
-	if resource == "namespaces" || resource == "clusterroles" || resource == "clusterrolebindings" {
-		return true
-	}
-
-	return false
+	return resource == "namespaces" || resource == "clusterroles" || resource == "clusterrolebindings"
 }

--- a/internal/clients/kube/apply_client_test.go
+++ b/internal/clients/kube/apply_client_test.go
@@ -2,6 +2,7 @@ package kube_test
 
 import (
 	"context"
+	"github.com/crossplane/crossplane-runtime/pkg/logging"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -17,7 +18,7 @@ var (
 )
 
 func TestApplyClient_EmptyManifests(t *testing.T) {
-	applyClient, err := kube.NewApplyClient(dynamic.NewSimpleDynamicClient(scheme.Scheme), fake.NewSimpleClientset())
+	applyClient, err := kube.NewApplyClient(dynamic.NewSimpleDynamicClient(scheme.Scheme), fake.NewSimpleClientset(), logging.NewNopLogger())
 	require.NoError(t, err)
 
 	err = applyClient.ApplyManifests(ctx, "", false)
@@ -25,7 +26,7 @@ func TestApplyClient_EmptyManifests(t *testing.T) {
 }
 
 func TestApplyClient_ApplyManifestsInvalidKindErr(t *testing.T) {
-	applyClient, err := kube.NewApplyClient(dynamic.NewSimpleDynamicClient(scheme.Scheme), fake.NewSimpleClientset())
+	applyClient, err := kube.NewApplyClient(dynamic.NewSimpleDynamicClient(scheme.Scheme), fake.NewSimpleClientset(), logging.NewNopLogger())
 	require.NoError(t, err)
 
 	err = applyClient.ApplyManifests(ctx, "apiVersion: v1\nkind: InvalidKind\nmetadata:\n  name: test-pod", false)

--- a/internal/clients/kube/apply_client_test.go
+++ b/internal/clients/kube/apply_client_test.go
@@ -2,8 +2,9 @@ package kube_test
 
 import (
 	"context"
-	"github.com/crossplane/crossplane-runtime/pkg/logging"
 	"testing"
+
+	"github.com/crossplane/crossplane-runtime/pkg/logging"
 
 	"github.com/stretchr/testify/require"
 	dynamic "k8s.io/client-go/dynamic/fake"
@@ -13,9 +14,7 @@ import (
 	"github.com/akuityio/provider-crossplane-akuity/internal/clients/kube"
 )
 
-var (
-	ctx = context.TODO()
-)
+var ctx = context.TODO()
 
 func TestApplyClient_EmptyManifests(t *testing.T) {
 	applyClient, err := kube.NewApplyClient(dynamic.NewSimpleDynamicClient(scheme.Scheme), fake.NewSimpleClientset(), logging.NewNopLogger())


### PR DESCRIPTION
<!--
Thank you for helping to improve the Akuity Crossplane Provider!
-->

### Description of your changes

There are some use cases where we'd want to use an existing namespace. Without this patch, we can get a client-side conflict. If the namespace already exists, just add the label metadata to the namespace and don't touch anything else. For any other resource we should keep the existing behavior.

### How has this code been tested

With a cluster that has a pre-existing namespace.
