### PR TITLE
fix: wrong cluster and instance external name

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ running cluster:
 
 ```
 make generate
-kubectl apply -f packages/crds/
+kubectl apply -f package/crds/
 ```
 
 If you need to make changes to the provider Go code, you can Ctrl-C to quit the binary

--- a/internal/clients/akuity/client.go
+++ b/internal/clients/akuity/client.go
@@ -11,6 +11,8 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/structpb"
 
+	"github.com/avast/retry-go/v4"
+
 	"github.com/akuity/api-client-go/pkg/api/gateway/accesscontrol"
 	argocdv1 "github.com/akuity/api-client-go/pkg/api/gen/argocd/v1"
 	idv1 "github.com/akuity/api-client-go/pkg/api/gen/types/id/v1"
@@ -21,7 +23,6 @@ import (
 	"github.com/akuityio/provider-crossplane-akuity/internal/types"
 	akuitytypes "github.com/akuityio/provider-crossplane-akuity/internal/types/generated/akuity/v1alpha1"
 	"github.com/akuityio/provider-crossplane-akuity/internal/utils/protobuf"
-	"github.com/avast/retry-go/v4"
 )
 
 const (
@@ -228,7 +229,7 @@ func (c client) DeleteInstance(ctx context.Context, name string) error {
 }
 
 func (c client) BuildApplyInstanceRequest(instance crossplanetypes.Instance) (*argocdv1.ApplyInstanceRequest, error) {
-	argocdPB, err := types.CrossplaneToAkuityAPIArgoCD(instance.Name, instance.Spec.ForProvider.ArgoCD)
+	argocdPB, err := types.CrossplaneToAkuityAPIArgoCD(instance.Spec.ForProvider.Name, instance.Spec.ForProvider.ArgoCD)
 	if err != nil {
 		return nil, fmt.Errorf("could not marshal instance argocd spec to protobuf: %w", err)
 	}
@@ -276,7 +277,7 @@ func (c client) BuildApplyInstanceRequest(instance crossplanetypes.Instance) (*a
 	request := &argocdv1.ApplyInstanceRequest{
 		OrganizationId:            c.organizationID,
 		IdType:                    idv1.Type_NAME,
-		Id:                        instance.Name,
+		Id:                        instance.Spec.ForProvider.Name,
 		Argocd:                    argocdPB,
 		ArgocdConfigmap:           argocdConfigMapPB,
 		ArgocdRbacConfigmap:       argocdRbacConfigMapPB,

--- a/internal/controller/cluster/cluster_test.go
+++ b/internal/controller/cluster/cluster_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"testing"
 
-	health "github.com/akuity/api-client-go/pkg/api/gen/types/status/health/v1"
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
@@ -32,6 +31,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubectl/pkg/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	health "github.com/akuity/api-client-go/pkg/api/gen/types/status/health/v1"
 
 	"github.com/akuityio/provider-crossplane-akuity/apis/core/v1alpha1"
 	mock_akuity_client "github.com/akuityio/provider-crossplane-akuity/internal/clients/akuity/mock"
@@ -303,7 +304,13 @@ func TestObserve_EmptyExternalName(t *testing.T) {
 	mockAkuityClient := mock_akuity_client.NewMockClient(gomock.NewController(t))
 	client := cluster.NewExternal(mockAkuityClient, fake.NewClientBuilder().Build(), logging.NewNopLogger())
 
-	resp, err := client.Observe(ctx, &v1alpha1.Cluster{})
+	resp, err := client.Observe(ctx, &v1alpha1.Cluster{
+		Spec: v1alpha1.ClusterSpec{
+			ForProvider: v1alpha1.ClusterParameters{
+				InstanceID: "test",
+			},
+		},
+	})
 	require.NoError(t, err)
 	assert.Equal(t, managed.ExternalObservation{ResourceExists: false}, resp)
 }

--- a/internal/controller/instance/instance.go
+++ b/internal/controller/instance/instance.go
@@ -25,7 +25,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	argocdv1 "github.com/akuity/api-client-go/pkg/api/gen/argocd/v1"
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/connection"
 	"github.com/crossplane/crossplane-runtime/pkg/controller"
@@ -35,6 +34,8 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/ratelimiter"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
+
+	argocdv1 "github.com/akuity/api-client-go/pkg/api/gen/argocd/v1"
 
 	"github.com/akuityio/provider-crossplane-akuity/apis/core/v1alpha1"
 	apisv1alpha1 "github.com/akuityio/provider-crossplane-akuity/apis/v1alpha1"
@@ -72,7 +73,9 @@ func Setup(mgr ctrl.Manager, o controller.Options) error {
 		managed.WithLogger(logger),
 		managed.WithPollInterval(o.PollInterval),
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
-		managed.WithConnectionPublishers(cps...))
+		managed.WithConnectionPublishers(cps...),
+		managed.WithInitializers(),
+	)
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
@@ -194,6 +197,7 @@ func (c *External) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 	}
 
 	err = c.client.ApplyInstance(ctx, request)
+	meta.SetExternalName(managedInstance, request.Id)
 
 	return managed.ExternalCreation{}, err
 }

--- a/internal/controller/instance/instance.go
+++ b/internal/controller/instance/instance.go
@@ -197,7 +197,7 @@ func (c *External) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 	}
 
 	err = c.client.ApplyInstance(ctx, request)
-	meta.SetExternalName(managedInstance, request.Id)
+	meta.SetExternalName(managedInstance, request.GetId())
 
 	return managed.ExternalCreation{}, err
 }


### PR DESCRIPTION
This PR fixes a bug that the Instance and Cluster CR names were used as the external names, which causes unexpected behavior if user uses different names for CR and AKP instance and cluster.

The external name should be set to the instance and cluster names on AKP side.