### PR TITLE
chore: align provider with crossplane-runtime v1.20

### DIFF
--- a/apis/v1alpha1/storeconfig_types.go
+++ b/apis/v1alpha1/storeconfig_types.go
@@ -37,11 +37,11 @@ type StoreConfigStatus struct {
 
 // +kubebuilder:object:root=true
 
-// A StoreConfig configures how GCP controller should store connection details.
+// A StoreConfig configures how Akuity controller should store connection details.
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:printcolumn:name="TYPE",type="string",JSONPath=".spec.type"
 // +kubebuilder:printcolumn:name="DEFAULT-SCOPE",type="string",JSONPath=".spec.defaultScope"
-// +kubebuilder:resource:scope=Cluster,categories={crossplane,store,gcp}
+// +kubebuilder:resource:scope=Cluster,categories={crossplane,store,akuity}
 // +kubebuilder:subresource:status
 type StoreConfig struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -25,7 +25,9 @@ import (
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	"github.com/crossplane/crossplane-runtime/pkg/controller"
 	"github.com/crossplane/crossplane-runtime/pkg/feature"
@@ -47,7 +49,8 @@ func main() {
 		pollInterval     = app.Flag("poll", "How often individual resources will be checked for drift from the desired state").Default("1m").Duration()
 		maxReconcileRate = app.Flag("max-reconcile-rate", "The global maximum rate per second at which resources may checked for drift from the desired state.").Default("10").Int()
 
-		enableManagementPolicies = app.Flag("enable-management-policies", "Enable support for Management Policies.").Default("false").Envar("ENABLE_MANAGEMENT_POLICIES").Bool()
+		enableManagementPolicies     = app.Flag("enable-management-policies", "Enable support for Management Policies.").Default("true").Envar("ENABLE_MANAGEMENT_POLICIES").Bool()
+		enableExternalSecretStores = app.Flag("enable-external-secret-stores", "Enable support for External Secret Stores.").Default("false").Envar("ENABLE_EXTERNAL_SECRET_STORES").Bool()
 	)
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 
@@ -80,9 +83,15 @@ func main() {
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 		LeaseDuration:              func() *time.Duration { d := 60 * time.Second; return &d }(),
 		RenewDeadline:              func() *time.Duration { d := 50 * time.Second; return &d }(),
+		HealthProbeBindAddress:     ":8081",
+		Metrics: metricsserver.Options{
+			BindAddress: ":8080",
+		},
 	})
 	kingpin.FatalIfError(err, "Cannot create controller manager")
 	kingpin.FatalIfError(apis.AddToScheme(mgr.GetScheme()), "Cannot add Akuity APIs to scheme")
+	kingpin.FatalIfError(mgr.AddHealthzCheck("healthz", healthz.Ping), "Cannot add healthz check")
+	kingpin.FatalIfError(mgr.AddReadyzCheck("readyz", healthz.Ping), "Cannot add readyz check")
 
 	o := controller.Options{
 		Logger:                  log,
@@ -93,8 +102,13 @@ func main() {
 	}
 
 	if *enableManagementPolicies {
-		o.Features.Enable(features.EnableAlphaManagementPolicies)
-		log.Info("Alpha feature enabled", "flag", features.EnableAlphaManagementPolicies)
+		o.Features.Enable(features.EnableBetaManagementPolicies)
+		log.Info("Beta feature enabled", "flag", features.EnableBetaManagementPolicies)
+	}
+
+	if *enableExternalSecretStores {
+		o.Features.Enable(features.EnableAlphaExternalSecretStores)
+		log.Info("Alpha feature enabled", "flag", features.EnableAlphaExternalSecretStores)
 	}
 
 	kingpin.FatalIfError(akuity.Setup(mgr, o), "Cannot setup Akuity controllers")

--- a/examples/provider/provider.yaml
+++ b/examples/provider/provider.yaml
@@ -5,18 +5,24 @@ metadata:
   name: akuity
 spec:
   package: us-docker.pkg.dev/akuity/crossplane/provider:v0.3.0
-  controllerConfigRef:
+  runtimeConfigRef:
     name: akuity
 ---
-apiVersion: pkg.crossplane.io/v1alpha1
-kind: ControllerConfig
+apiVersion: pkg.crossplane.io/v1beta1
+kind: DeploymentRuntimeConfig
 metadata:
   name: akuity
 spec:
-  args:
-    - --debug
-  podSecurityContext:
-    fsGroup: 2000
+  deploymentTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: package-runtime
+              args:
+                - --debug
+          securityContext:
+            fsGroup: 2000
 ---
 apiVersion: v1
 kind: Secret

--- a/internal/controller/cluster/cluster.go
+++ b/internal/controller/cluster/cluster.go
@@ -68,8 +68,7 @@ func Setup(mgr ctrl.Manager, o controller.Options) error {
 
 	logger := o.Logger.WithValues("controller", name)
 
-	r := managed.NewReconciler(mgr,
-		resource.ManagedKind(v1alpha1.ClusterGroupVersionKind),
+	opts := []managed.ReconcilerOption{
 		managed.WithExternalConnecter(&connector{
 			kube:   mgr.GetClient(),
 			usage:  resource.NewProviderConfigUsageTracker(mgr.GetClient(), &apisv1alpha1.ProviderConfigUsage{}),
@@ -80,6 +79,15 @@ func Setup(mgr ctrl.Manager, o controller.Options) error {
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithConnectionPublishers(cps...),
 		managed.WithInitializers(),
+	}
+
+	if o.Features.Enabled(features.EnableBetaManagementPolicies) {
+		opts = append(opts, managed.WithManagementPolicies())
+	}
+
+	r := managed.NewReconciler(mgr,
+		resource.ManagedKind(v1alpha1.ClusterGroupVersionKind),
+		opts...,
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/instance/instance.go
+++ b/internal/controller/instance/instance.go
@@ -66,8 +66,7 @@ func Setup(mgr ctrl.Manager, o controller.Options) error {
 
 	logger := o.Logger.WithValues("controller", name)
 
-	r := managed.NewReconciler(mgr,
-		resource.ManagedKind(v1alpha1.InstanceGroupVersionKind),
+	opts := []managed.ReconcilerOption{
 		managed.WithExternalConnecter(&connector{
 			kube:   mgr.GetClient(),
 			usage:  resource.NewProviderConfigUsageTracker(mgr.GetClient(), &apisv1alpha1.ProviderConfigUsage{}),
@@ -78,6 +77,15 @@ func Setup(mgr ctrl.Manager, o controller.Options) error {
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithConnectionPublishers(cps...),
 		managed.WithInitializers(),
+	}
+
+	if o.Features.Enabled(features.EnableBetaManagementPolicies) {
+		opts = append(opts, managed.WithManagementPolicies())
+	}
+
+	r := managed.NewReconciler(mgr,
+		resource.ManagedKind(v1alpha1.InstanceGroupVersionKind),
+		opts...,
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -25,8 +25,8 @@ const (
 	// https://github.com/crossplane/crossplane/blob/390ddd/design/design-doc-external-secret-stores.md
 	EnableAlphaExternalSecretStores feature.Flag = "EnableAlphaExternalSecretStores"
 
-	// EnableAlphaManagementPolicies enables alpha support for
+	// EnableBetaManagementPolicies enables beta support for
 	// Management Policies. See the below design for more details.
 	// https://github.com/crossplane/crossplane/blob/master/design/design-doc-observe-only-resources.md
-	EnableAlphaManagementPolicies feature.Flag = "EnableAlphaManagementPolicies"
+	EnableBetaManagementPolicies feature.Flag = "EnableBetaManagementPolicies"
 )

--- a/package/crds/akuity.crossplane.io_storeconfigs.yaml
+++ b/package/crds/akuity.crossplane.io_storeconfigs.yaml
@@ -11,7 +11,7 @@ spec:
     categories:
     - crossplane
     - store
-    - gcp
+    - akuity
     kind: StoreConfig
     listKind: StoreConfigList
     plural: storeconfigs
@@ -31,7 +31,7 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: A StoreConfig configures how GCP controller should store connection
+        description: A StoreConfig configures how Akuity controller should store connection
           details.
         properties:
           apiVersion:


### PR DESCRIPTION
- Rename EnableAlphaManagementPolicies to EnableBetaManagementPolicies and default to enabled, matching the upstream promotion to beta
- Add health probe (:8081) and metrics (:8080) endpoints to the controller manager for Kubernetes readiness/liveness checks
- Expose EnableAlphaExternalSecretStores feature flag via --enable-external-secret-stores CLI flag
- Fix StoreConfig CRD category from "gcp" to "akuity" and update the resource description accordingly
- Replace deprecated ControllerConfig with DeploymentRuntimeConfig (v1beta1) in the provider example
- Wire WithManagementPolicies() into cluster and instance reconcilers when the beta feature flag is enabled

<!--
Thank you for helping to improve the Akuity Crossplane Provider!
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Akuity Crossplane Provider issue. 
If yours does, you can uncomment the below line to indicate which issue your PR 
fixes, for example "Fixes #500":

-->
Fixes #

### How has this code been tested

Manual installation of the provider. Don't have akutiry access.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
