### PR TITLE
fix: switch release publish to crossplane v2 CLI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
         run: |
           set -euo pipefail
           curl -sL https://raw.githubusercontent.com/crossplane/crossplane/v2.2.0/install.sh | XP_VERSION=v2.2.0 sh
-          sudo mv kubectl-crossplane /usr/local/bin
+          sudo mv crossplane /usr/local/bin
           make akuity-publish
         env:
           VERSION: ${{ github.ref_name }}

--- a/Makefile
+++ b/Makefile
@@ -167,7 +167,7 @@ crossplane.help:
 help-special: crossplane.help
 
 akuity-publish:
-	kubectl crossplane push provider -f _output/xpkg/linux_arm64/provider-crossplane-akuity-$(VERSION).xpkg \
+	crossplane xpkg push -f _output/xpkg/linux_arm64/provider-crossplane-akuity-$(VERSION).xpkg \
 		-f _output/xpkg/linux_amd64/provider-crossplane-akuity-$(VERSION).xpkg \
 		us-docker.pkg.dev/akuity/crossplane/provider:$(VERSION)
 


### PR DESCRIPTION
This PR fixes the release workflow, which was failing on `mv kubectl-crossplane` because the Crossplane v2.2.0 install script no longer ships the `kubectl-crossplane` plugin — it installs a single `crossplane` binary.

- Update `.github/workflows/release.yml` to move the `crossplane` binary instead of `kubectl-crossplane`
- Switch `make akuity-publish` from `kubectl crossplane push provider ...` to the canonical `crossplane xpkg push ...` so the publish step no longer depends on the deprecated kubectl plugin


example failure: https://github.com/akuity/provider-crossplane-akuity/actions/runs/25036557111/job/73329491733