### PR TITLE
ci: mirror release packages to Upbound Marketplace

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,16 @@ jobs:
           username: ${{ secrets.ARTIFACT_REGISTRY_USERNAME }}
           password: ${{ secrets.ARTIFACT_REGISTRY_PASSWORD }}
 
+      - name: Login to Upbound Marketplace
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          registry: xpkg.upbound.io
+          username: ${{ secrets.XPKG_MARKETPLACE_ACCESS_ID }}
+          password: ${{ secrets.XPKG_MARKETPLACE_TOKEN }}
+
+      - name: Install Crane
+        uses: imjasonh/setup-crane@6da1ae018866400525525ce74ff892880c099987 # v0.5
+
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:

--- a/Makefile
+++ b/Makefile
@@ -168,9 +168,21 @@ crossplane.help:
 
 help-special: crossplane.help
 
-akuity-publish:
+akuity-publish: akuity-publish.gar akuity-publish.marketplace
+
+akuity-publish.gar:
 	crossplane xpkg push -f _output/xpkg/linux_arm64/provider-crossplane-akuity-$(VERSION).xpkg \
 		-f _output/xpkg/linux_amd64/provider-crossplane-akuity-$(VERSION).xpkg \
 		us-docker.pkg.dev/akuity/crossplane/provider:$(VERSION)
+
+# Mirror the GAR-published xpkg to the Upbound Marketplace so the digest stays
+# identical across both registries. Requires `crane` on PATH and prior login to
+# xpkg.upbound.io. The --allow-nondistributable-artifacts flag is required
+# because xpkg layers use foreign-layer media types.
+akuity-publish.marketplace:
+	crane copy \
+		us-docker.pkg.dev/akuity/crossplane/provider:$(VERSION) \
+		xpkg.upbound.io/akuity/provider-crossplane-akuity:$(VERSION) \
+		--allow-nondistributable-artifacts
 
 .PHONY: crossplane.help help-special


### PR DESCRIPTION
This PR mirrors each tagged release to xpkg.upbound.io alongside the existing Google Artifact Registry push so the provider can be installed from the Upbound Marketplace with a digest identical to the GAR copy.

related to https://github.com/akuity/provider-crossplane-akuity/issues/43