### PR TITLE
fix(ci): pull-then-push Marketplace mirror to bypass cross-registry token bundling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,11 +80,16 @@ jobs:
           BUILD_ARGS: "--load"
           VERSION: ${{ github.ref_name }}
 
-      - name: Publish Artifacts
+      - name: Publish to Google Artifact Registry
         run: |
           set -euo pipefail
           curl -sL https://raw.githubusercontent.com/crossplane/crossplane/v2.2.0/install.sh | XP_VERSION=v2.2.0 sh
           sudo mv crossplane /usr/local/bin
-          make akuity-publish
+          make akuity-publish.gar
+        env:
+          VERSION: ${{ github.ref_name }}
+
+      - name: Mirror to Upbound Marketplace
+        run: make akuity-publish.marketplace
         env:
           VERSION: ${{ github.ref_name }}

--- a/Makefile
+++ b/Makefile
@@ -175,14 +175,25 @@ akuity-publish.gar:
 		-f _output/xpkg/linux_amd64/provider-crossplane-akuity-$(VERSION).xpkg \
 		us-docker.pkg.dev/akuity/crossplane/provider:$(VERSION)
 
-# Mirror the GAR-published xpkg to the Upbound Marketplace so the digest stays
-# identical across both registries. Requires `crane` on PATH and prior login to
-# xpkg.upbound.io. The --allow-nondistributable-artifacts flag is required
-# because xpkg layers use foreign-layer media types.
+# Mirror the GAR-published xpkg to the Upbound Marketplace via a pull-then-push
+# round-trip. `crane copy` cannot be used directly because xpkg.upbound.io's
+# token service rejects cross-registry blob-mount scopes that reference a
+# foreign GAR repository path. Pulling to a local OCI layout first decouples
+# the GAR pull auth from the Upbound push auth so neither registry is asked
+# for a token that names a repo it does not own. The OCI layout preserves the
+# multi-arch index. Requires `crane` on PATH and prior `docker login` to both
+# us-docker.pkg.dev and xpkg.upbound.io.
 akuity-publish.marketplace:
-	crane copy \
+	@set -euo pipefail; \
+	tmpdir="$$(mktemp -d)"; \
+	trap 'rm -rf "$$tmpdir"' EXIT; \
+	crane pull --format=oci \
+		--allow-nondistributable-artifacts \
 		us-docker.pkg.dev/akuity/crossplane/provider:$(VERSION) \
-		xpkg.upbound.io/akuity/provider-crossplane-akuity:$(VERSION) \
-		--allow-nondistributable-artifacts
+		"$$tmpdir/xpkg"; \
+	crane push \
+		--allow-nondistributable-artifacts \
+		"$$tmpdir/xpkg" \
+		xpkg.upbound.io/akuity/provider-crossplane-akuity:$(VERSION)
 
 .PHONY: crossplane.help help-special


### PR DESCRIPTION
This PR replaces the `crane copy` mirror to xpkg.upbound.io with a pull-then-push round-trip through a local OCI layout because the previous implementation fails with HTTP 400 from Upbound's token endpoint whenever the source GAR path differs from the destination Marketplace path.

- `crane copy` triggers cross-registry blob mount, which asks the destination registry for a single token covering both `akuity/crossplane/provider:pull` (source path) and `akuity/provider-crossplane-akuity:push,pull` (destination path); Upbound rejects the request because the source path does not exist on its registry
- Replace `akuity-publish.marketplace` with `crane pull --format=oci` followed by `crane push`, both with `--allow-nondistributable-artifacts` to keep xpkg foreign-layer media types intact
- Pulling to a local OCI layout decouples the GAR pull auth from the Upbound push auth so neither registry sees a scope referencing the other
- `--format=oci` preserves the multi-arch index so both `linux/amd64` and `linux/arm64` manifests reach Upbound under the same tag
- Split the release workflow's publish step into separate `Publish to Google Artifact Registry` and `Mirror to Upbound Marketplace` steps so Upbound failures do not re-run the GAR push
- The Upbound index manifest digest may differ from the GAR index manifest digest because crane re-serializes the index; the platform manifests and all layer blobs remain byte-identical, and consumers pull by tag rather than by index digest
