### PR TITLE
docs: align in-cluster RBAC example with agent manifests

### DIFF
--- a/examples/cluster/in-cluster-rbac.yaml
+++ b/examples/cluster/in-cluster-rbac.yaml
@@ -128,11 +128,38 @@ rules:
     verbs:
       - bind
       - escalate
-  # Modern Event resources used by some applied agent RBAC/manifests.
+  # PodDisruptionBudget + NetworkPolicy: agent manifest set includes
+  # akuity-agent PDB + akuity-agent-network-policy. Provider SSAs both
+  # directly through this ServiceAccount during install and removes them
+  # during teardown when removeAgentResourcesOnDestroy=true.
   - apiGroups:
-      - events.k8s.io
+      - policy
     resources:
-      - events
+      - poddisruptionbudgets
+    verbs:
+      - get
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - get
+      - create
+      - update
+      - patch
+      - delete
+  # MutatingWebhookConfiguration: self-hosted KargoAgent (akuityManaged: false)
+  # ships kargo-webhook MutatingWebhookConfiguration. Provider SSAs it through
+  # this ServiceAccount on install and removes it on teardown.
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - mutatingwebhookconfigurations
+      - validatingwebhookconfigurations
     verbs:
       - get
       - create


### PR DESCRIPTION
This PR updates the in-cluster provider RBAC example to match the current agent manifest resources managed during install and teardown.

- Replace the stale events RBAC entry with permissions for PodDisruptionBudgets and NetworkPolicies
- Add admissionregistration permissions for mutating and validating webhook configurations
- Document why these permissions are needed for agent install, teardown, and self-hosted KargoAgent manifests